### PR TITLE
Corrige o caminho para extração de holding

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -34,7 +34,7 @@ function extract_data() {
 }
 
 function extract_holding() {
-	time python extract_holding.py data/output-full/{socio,empresa,holding}.csv.gz
+	time python extract_holding.py data/output/{socio,empresa,holding}.csv.gz
 }
 
 function extract_cnae() {


### PR DESCRIPTION
Na chamada do `extract_holding.py`, caminho `data/output-full/socio.csv.gz` estava lançando a exceção `FileNotFoundError: [Errno 2] No such file or directory: 'data/output-full/socio.csv.gz'` e finalizando a execução do programa.