### PR TITLE
Corrigindo erro de digitação no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ comandos:
 ```bash
 DB_NAME="data/output/socios-brasil.sqlite"
 rows csv2sqlite --schemas=schema/empresa.csv data/output/empresa.csv.gz "$DB_NAME"
-rows csv2sqlite --schemas=schema/socio.csv data/output/holding.csv.gz "$DB_NAME"
+rows csv2sqlite --schemas=schema/holding.csv data/output/holding.csv.gz "$DB_NAME"
 rows csv2sqlite --schemas=schema/socio.csv data/output/socio.csv.gz "$DB_NAME"
 rows csv2sqlite --schemas=schema/cnae-secundaria.csv data/output/cnae-secundaria.csv.gz "$DB_NAME"
 ```


### PR DESCRIPTION
Quando fui rodar o código que cria o banco de dados SQLite obtive um erro aqui.

```bash
DB_NAME="data/output/socios-brasil.sqlite"
rows csv2sqlite --schemas=schema/empresa.csv data/output/empresa.csv.gz "$DB_NAME"
rows csv2sqlite --schemas=schema/socio.csv data/output/holding.csv.gz "$DB_NAME"
rows csv2sqlite --schemas=schema/socio.csv data/output/socio.csv.gz "$DB_NAME"
rows csv2sqlite --schemas=schema/cnae-secundaria.csv data/output/cnae-secundaria.csv.gz "$DB_NAME"
```
A terceira linha (que puxa o holding.csv) esta com o schema socio.csv.
Para corrigir, apenas mudei o schema de `socio` para `holding` e deu certo.